### PR TITLE
Used tokens count endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
     volumes:
       - ./src:/app/src
       - ./.env:/app/.env
-      - ./ner_model:${DATA_FOLDER_PATH}/ner_model
       - server:${DATA_FOLDER_PATH}
 
   ner:

--- a/src/app.py
+++ b/src/app.py
@@ -16,6 +16,7 @@ from controller.chroma_collection import chroma_collection_controller
 from controller.classifier import classifier_config_controller, classifier_controller
 from controller.embedding import embedding_controller
 from controller.file import file_controller
+from controller.ksr import ksr_controller
 from controller.mapping import mapping_controller
 from controller.mode import mode_controller
 from controller.ner import brand_model_controller
@@ -23,8 +24,8 @@ from controller.prediction import prediction_controller
 from controller.prompt import prompt_controller
 from controller.task import task_controller
 from controller.tenant import tenant_controller
+from controller.used_token import used_token_controller
 from controller.user import user_controller
-from controller.ksr import ksr_controller
 
 app = FastAPI()
 
@@ -51,6 +52,9 @@ app.include_router(embedding_controller.router, tags=["embedding"], prefix="/emb
 app.include_router(chroma_collection_controller.router, tags=["chroma_collection"], prefix="/collection")
 app.include_router(classifier_controller.router, tags=["classifier"], prefix="/classifier")
 app.include_router(brand_model_controller.router, tags=["ner_brand"], prefix="/ner_brand")
+
+# Used Tokens
+app.include_router(used_token_controller.router, tags=["used_token"], prefix="/used_token")
 
 # Other
 app.include_router(task_controller.router, tags=["task"], prefix="/task")

--- a/src/controller/used_token/used_token_controller.py
+++ b/src/controller/used_token/used_token_controller.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends, Query
+from fastapi_versioning import version
+from sqlmodel import Session
+
+from infra.database import get_session
+from model.auth.auth_model import get_current_user
+from model.used_token import used_token_model
+from scheme.user.user_scheme import UserRead
+
+router = APIRouter()
+
+
+@router.get("/{tenant_id}", response_model=int)
+@version(1)
+def get_tenant_used_tokens_by_month(
+    tenant_id: int,
+    month: int | None = Query(
+        None,
+        description="Month number, e.g. 1 is Jan. **Default:** _current month_",
+    ),
+    session: Session = Depends(get_session),
+    current_user: UserRead = Depends(get_current_user),
+) -> int:
+    """
+    Получает количество потраченных токенов тенанта за последний месяц.
+    """
+    return used_token_model.get_tenant_used_tokens_by_month(session, tenant_id, month)

--- a/src/model/used_token/used_token_model.py
+++ b/src/model/used_token/used_token_model.py
@@ -1,5 +1,10 @@
+from fastapi import HTTPException, status
+from sqlmodel import Session
+
+from repository.used_token import used_token_repository
 from repository.used_token.used_token_repository import create_used_token
 from scheme.used_token.used_token_scheme import UsedToken
+from util.dates import get_current_month
 
 
 def count_used_tokens(nomenclatures: list) -> int:
@@ -14,3 +19,28 @@ def charge_used_tokens(tokens_count: int, tenant_id: int, user_id: int):
         user_id=user_id,
     )
     create_used_token(used_tokens)
+
+
+def get_tenant_used_tokens_by_month(
+    session: Session,
+    tenant_id: int,
+    month: int | None,
+) -> int:
+    if month is None:
+        month = get_current_month()
+
+    print(month)
+
+    if month < 1 or month > 12:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Month must be 1-12."
+        )
+
+    tenant_used_tokens = used_token_repository.get_tenant_used_tokens_by_month(
+        session=session,
+        tenant_id=tenant_id,
+        month=month,
+    )
+    tokens_count = sum(used_token.tokens_count for used_token in tenant_used_tokens)
+    return tokens_count

--- a/src/repository/used_token/used_token_repository.py
+++ b/src/repository/used_token/used_token_repository.py
@@ -1,7 +1,17 @@
-from sqlmodel import Session
+from sqlmodel import Session, select, extract
 
 from infra.database import engine
 from scheme.used_token.used_token_scheme import UsedToken
+
+
+def get_tenant_used_tokens_by_month(session: Session, tenant_id: int, month: int) -> list[UsedToken]:
+    st = select(UsedToken).where(
+        UsedToken.tenant_id == tenant_id
+    ).where(
+        extract('month', UsedToken.used_at) == month
+    )
+    result = list(session.exec(st).all())
+    return result
 
 
 def create_used_token(used_token: UsedToken) -> UsedToken:

--- a/src/util/dates.py
+++ b/src/util/dates.py
@@ -1,0 +1,7 @@
+from datetime import datetime
+
+
+def get_current_month() -> int:
+    now = datetime.now()
+    current_month = now.month
+    return int(current_month)


### PR DESCRIPTION
- Сделал ручку, чтобы получать кол-во потраченных токенов тенанта по месяцу. Если не указывать месяц, то подефолту будет браться текущий месяц.
- Убрать в `docker-compose` в контейнере бэка монтирование папки для `ner brands`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint to retrieve the number of tokens consumed by a tenant for a specific month.
  - Introduced a utility function to obtain the current month.

- **Bug Fixes**
  - Removed volume mapping for the `ner_model`, potentially improving service configuration.

- **Documentation**
  - Enhanced API routing structure by updating the included routers for better clarity and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->