### PR TITLE
refactor: classifier config by user id, not current user id

### DIFF
--- a/src/controller/classifier/classifier_config_controller.py
+++ b/src/controller/classifier/classifier_config_controller.py
@@ -4,7 +4,6 @@ from fastapi_versioning import version
 from sqlmodel import Session
 
 from infra.database import get_session
-from middleware.mode_middleware import TenantMode, modes_required
 from middleware.role_middleware import admins_only
 from model.auth.auth_model import get_current_user
 from model.classifier import classifier_config_model
@@ -14,39 +13,41 @@ from scheme.user.user_scheme import UserRead
 router = APIRouter()
 
 
-@router.get("", response_model=ClassifierConfig)
+@router.get("/{user_id}", response_model=ClassifierConfig)
 @version(1)
-@modes_required([TenantMode.CLASSIFIER])
+# @modes_required([TenantMode.CLASSIFIER])
+@admins_only
 def get_classifier_config_by_user_id(
+    user_id: int,
     session: Session = Depends(get_session),
     current_user: UserRead = Depends(get_current_user)
 ) -> ClassifierConfig:
     """
-    Получает конфиг классификатора для текущего юзера.
+    Получает конфиг классификатора по ID юзера.
     """
-    user_id = current_user.id
     return classifier_config_model.get_classifier_config_by_user_id(session, user_id)
 
 
-@router.post("", response_model=ClassifierConfig)
+@router.post("/{user_id}", response_model=ClassifierConfig)
 @version(1)
 @admins_only
 def create_classifier_config(
+    user_id: int,
     body: ClassifierConfigBase,
     session: Session = Depends(get_session),
     current_user: UserRead = Depends(get_current_user)
 ) -> ClassifierConfig:
     """
-    Создаёт конфиг классификатора для текущего юзера.
+    Создаёт конфиг классификатора по ID юзера.
     """
-    user_id = current_user.id
     return classifier_config_model.create_classifier_config(session, body, user_id)
 
 
-@router.put("", response_model=ClassifierConfig)
+@router.put("/{user_id}", response_model=ClassifierConfig)
 @version(1)
 @admins_only
 def update_classifier_config_by_user_id(
+    user_id: int,
     body: ClassifierConfigBase,
     session: Session = Depends(get_session),
     current_user: UserRead = Depends(get_current_user)
@@ -54,19 +55,18 @@ def update_classifier_config_by_user_id(
     """
     Обновляет параметры в конфиге классификатора для текущего юзера.
     """
-    user_id = current_user.id
     return classifier_config_model.update_classifier_config_by_user_id(session, body, user_id)
 
 
-@router.delete("", response_model=None)
+@router.delete("/{user_id}", response_model=None)
 @version(1)
 @admins_only
 def delete_classifier_config_by_user_id(
+    user_id: int,
     session: Session = Depends(get_session),
     current_user: UserRead = Depends(get_current_user)
 ) -> None:
     """
     Удаляет конфиг классификатора для текущего юзера.
     """
-    user_id = current_user.id
     return classifier_config_model.delete_classifier_config_by_user_id(session, user_id)

--- a/src/model/classifier/classifier_config_model.py
+++ b/src/model/classifier/classifier_config_model.py
@@ -25,6 +25,14 @@ def create_classifier_config(
     config_params: ClassifierConfigBase,
     user_id: int,
 ) -> ClassifierConfig:
+    classifier_config = classifier_config_repository.get_classifier_config_by_user_id(session, user_id)
+
+    if classifier_config is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"User with ID {user_id} already have config for classifier.",
+        )
+
     config = ClassifierConfig(
         **ClassifierConfigBase.dict(config_params),
         user_id=user_id,
@@ -44,10 +52,13 @@ def update_classifier_config_by_user_id(
 
     classifier_config = ClassifierConfig.from_orm(
         obj=classifier_config,
-        update=ClassifierConfigBase.dict(config_params),
+        update=ClassifierConfigBase.dict(config_params, exclude_none=True),
     )
 
-    classifier_config = classifier_config_repository.update_classifier_config(session, classifier_config)
+    classifier_config = classifier_config_repository.update_classifier_config(
+        session=session,
+        classifier_config=classifier_config,
+    )
 
     return classifier_config
 

--- a/src/repository/classifier/classifier_config_repository.py
+++ b/src/repository/classifier/classifier_config_repository.py
@@ -4,15 +4,18 @@ from scheme.classifier.classifier_config_scheme import ClassifierConfig
 
 
 def get_classifier_config_by_user_id(session: Session, user_id: int) -> ClassifierConfig | None:
-    st = select(ClassifierConfig) \
-        .where(ClassifierConfig.user_id == user_id)
+    st = select(ClassifierConfig)
+    st = st.where(ClassifierConfig.user_id == user_id)
 
     classifier_config = session.exec(st).first()
 
     return classifier_config
 
 
-def create_classifier_config(session: Session, classifier_config: ClassifierConfig) -> ClassifierConfig:
+def create_classifier_config(
+    session: Session,
+    classifier_config: ClassifierConfig,
+) -> ClassifierConfig:
     session.add(classifier_config)
     session.commit()
     session.refresh(classifier_config)
@@ -20,7 +23,10 @@ def create_classifier_config(session: Session, classifier_config: ClassifierConf
     return classifier_config
 
 
-def update_classifier_config(session: Session, classifier_config: ClassifierConfig) -> ClassifierConfig:
+def update_classifier_config(
+    session: Session,
+    classifier_config: ClassifierConfig,
+) -> ClassifierConfig:
     new_classifier_config = session.merge(classifier_config)
     session.commit()
 

--- a/src/scheme/classifier/classifier_config_scheme.py
+++ b/src/scheme/classifier/classifier_config_scheme.py
@@ -2,11 +2,11 @@ from sqlmodel import SQLModel, Field, Relationship
 
 
 class ClassifierConfigBase(SQLModel):
-    is_use_keywords_detection: bool | None = Field(default=False)
     chroma_collection_name: str | None
     model_id: str | None = Field(foreign_key="classifier_version.id")
-    is_use_params: bool | None = Field(default=False)
     nomenclatures_table_name: str | None
+    is_use_keywords_detection: bool | None = Field(default=False)
+    is_use_params: bool | None = Field(default=False)
     is_use_brand_recognition: bool | None = Field(default=False)
 
 


### PR DESCRIPTION
- Поправил ручки конфига Классификатора, чтобы они принимали `user_id`, а не `ID` текущего юзера
- Поправил ручку на обновление конфига Классификатора, чтобы можно было передавать только обновлённые параметры